### PR TITLE
Bug fix for evaluation

### DIFF
--- a/test.py
+++ b/test.py
@@ -73,7 +73,7 @@ def main():
     if not os.path.isdir(output_dir):
         os.mkdir(output_dir)
 
-    errors = np.zeros((2, 8, int(len(val_loader)/args.print_freq)+1), np.float32)
+    errors = np.zeros((2, 8, int(np.ceil(len(val_loader)/args.print_freq))), np.float32)
     with torch.no_grad():
         for ii, (tgt_img, ref_imgs, ref_poses, intrinsics, intrinsics_inv, tgt_depth) in enumerate(val_loader):
             if ii % args.print_freq == 0:

--- a/test_ETH3D.py
+++ b/test_ETH3D.py
@@ -71,7 +71,7 @@ def main():
     if not os.path.isdir(output_dir):
         os.mkdir(output_dir)
 
-    errors = np.zeros((2, 8, int(len(val_loader)/args.print_freq)+1), np.float32)
+    errors = np.zeros((2, 8, int(np.ceil(len(val_loader)/args.print_freq))), np.float32)
     with torch.no_grad():
         for ii, (tgt_img, ref_imgs, ref_poses, intrinsics, intrinsics_inv, tgt_depth, scale_) in enumerate(val_loader):
             if ii % args.print_freq == 0:


### PR DESCRIPTION
Hi! Thanks for sharing this!

I noticed that the last element of `errors` in test.py and test_ETH3D.py is always zero if `len(val_loader)%args.print_freq == 0`. Therefore, the evaluated error `errors.mean(2)` is not correct.

I fixed it by `np.ceil` instead of adding one. Let me know if there are any problems.

Thanks!